### PR TITLE
Bugfix: Missing Map Files

### DIFF
--- a/src/client/component/fastfiles.cpp
+++ b/src/client/component/fastfiles.cpp
@@ -1187,9 +1187,38 @@ namespace fastfiles
 		return utils::io::file_exists(utils::string::va("hmw-usermaps\\%s\\%s.ff", name.data(), name.data()));
 	}
 
+	bool is_dlc_map(const std::string& name)
+	{
+		const std::vector<std::string> dlc_zone_basenames = {
+				"carentan",
+				"broadcast",
+				"creek",
+				"killhouse"
+		};
+
+		return std::any_of(dlc_zone_basenames.begin(), dlc_zone_basenames.end(), [&](std::string base) {
+			return name.contains(base);
+			});
+	}
+
 	bool is_stock_map(const std::string& name)
 	{
 		return fastfiles::exists(name, true);
+	}
+
+	MAP_EXISTS_RESULT map_exists(const std::string& mapname)
+	{
+
+		if (fastfiles::is_dlc_map(mapname) && fastfiles::exists(mapname)) { return MAP_EXISTS_RESULT::DLC;  }
+
+		// michelin: I'm not a fan of the existing is_stock_map  or the fastfiles::exists logic. 
+		// we should NOT be checking if a file is in root/zone to see if a map is a stock map... we should be checking a table of mapnames
+		// the exists check should be explicit and separate, like I've expressed here
+		if (fastfiles::is_stock_map(mapname) && fastfiles::exists(mapname)) { return MAP_EXISTS_RESULT::BASE_GAME;  }
+
+		if (fastfiles::usermap_exists(mapname)) { return MAP_EXISTS_RESULT::USER;  }
+
+		return MAP_EXISTS_RESULT::MISSING;
 	}
 
 	void enum_asset_entries(const game::XAssetType type, const std::function<void(game::XAssetEntry*)>& callback, bool include_override)

--- a/src/client/component/fastfiles.hpp
+++ b/src/client/component/fastfiles.hpp
@@ -20,6 +20,17 @@ namespace fastfiles
 	std::optional<std::string> get_current_usermap();
 	bool usermap_exists(const std::string& name);
 	bool is_stock_map(const std::string& name);
+	bool is_dlc_map(const std::string& name);
+
+	enum class MAP_EXISTS_RESULT {
+		BASE_GAME,
+		DLC,
+		USER,
+		MISSING
+	};
+
+	MAP_EXISTS_RESULT map_exists(const std::string& name);
+	
 
 	void enum_asset_entries(const game::XAssetType type, const std::function<void(game::XAssetEntry*)>& callback, bool include_override);
 }

--- a/src/client/tcp/hmw_tcp_utils.cpp
+++ b/src/client/tcp/hmw_tcp_utils.cpp
@@ -259,7 +259,7 @@ namespace hmw_tcp_utils {
 		void check_download_map_tcp(const nlohmann::json infoJson, std::vector<download::file_t>& files)
 		{
 			const std::string mapname = infoJson["mapname"];
-			if (fastfiles::is_stock_map(mapname))
+			if (fastfiles::is_stock_map(mapname) || fastfiles::is_dlc_map(mapname))
 			{
 				return;
 			}


### PR DESCRIPTION
## **Description:**

Addresses JSON 302 bug.

### **Observed behavior:**

The client is using a "file exists" check to determine if a map was base game or usermap, assuming all base game and DLC files should always be present. This check resulted in unintended behavior when connecting to a server where-- if the client was missing a map-- the client would expect the usermap_hash when parsing the jsonInfo object from the server's CURL string. This missing json object key would result in a hanging connection state which required a full client restart. Users would simply received a JSON 302 error and have to restart the client if this happened. 

Typically affected users were those who did not own the MWR DLC.

### **Expected behavior:**

Joining a server which is hosting a map you do not own should result in a client error notification explaining they don't have the map, and then the client should return to the main MP lobby or the main menu screen.

### **Changes:**

- Created a single `map_exists()` function which returns the map type for a file as an enum or the enum value `MISSING` if the file doesn't actually exist in the filesystem.
- Added an `is_dlc_map()` check which parses map strings for the 4 dlc map base names
- Added calls to the above checks to the `set_new_map()` and `connect_to_server_tcp()` functions which handle disconnecting and notifying the player of missing files instead of crashing the game or putting the client in a bugged state.

### **TODO:**
In the future I would like to further improve the map file checks to include a LUT of all base game filenames so we can separate the exists() and is_stock_map() functions properly. The client should NOT be using exists to determine the difference between stock maps and usermaps.